### PR TITLE
fix(ci): Update Swift version to 6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Swift
         uses: swift-actions/setup-swift@v2
         with:
-          swift-version: "5.10"
+          swift-version: "6.0"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- CI 워크플로우의 Swift 버전을 5.10에서 6.0으로 업데이트
- `native/Package.swift`가 `swift-tools-version: 6.0`을 요구하지만 CI는 5.10을 사용하여 모든 빌드가 실패하던 문제 수정

## Test plan
- [ ] GitHub Actions 빌드가 성공하는지 확인