### PR TITLE
docs: use @latest tag for npx/bunx to ensure latest version

### DIFF
--- a/README-KR.md
+++ b/README-KR.md
@@ -36,7 +36,7 @@ TypeScript MCP 레이어와 Swift 네이티브 브리지를 사용하는 iOS 시
 
 ```bash
 # 설치 없이 바로 실행
-npx mcp-baepsae
+npx mcp-baepsae@latest
 
 # 또는 전역 설치
 npm install -g mcp-baepsae
@@ -89,10 +89,10 @@ bash scripts/install.sh --tool all
 
 ```bash
 # Claude Code
-claude mcp add baepsae -- npx -y mcp-baepsae
+claude mcp add baepsae -- npx -y mcp-baepsae@latest
 
 # Codex CLI
-codex mcp add baepsae -- npx -y mcp-baepsae
+codex mcp add baepsae -- npx -y mcp-baepsae@latest
 ```
 
 ### 자동화 옵션
@@ -115,8 +115,8 @@ bash scripts/install.sh --tool all --uninstall
 | 플래그 | 명령어 | 사용 시점 |
 |---|---|---|
 | `--runtime node` (기본값) | `node dist/index.js` | 소스 빌드 |
-| `--runtime npx` | `npx -y mcp-baepsae` | npm 레지스트리, 전역 설치 불필요 |
-| `--runtime bunx` | `bunx mcp-baepsae` | Bun 사용자 |
+| `--runtime npx` | `npx -y mcp-baepsae@latest` | npm 레지스트리, 전역 설치 불필요 |
+| `--runtime bunx` | `bunx mcp-baepsae@latest` | Bun 사용자 |
 | `--runtime global` | `mcp-baepsae` | `npm install -g mcp-baepsae` 이후 |
 
 ## 수동 설정 (대안)
@@ -127,13 +127,13 @@ bash scripts/install.sh --tool all --uninstall
 
 ```bash
 # Claude Code
-claude mcp add baepsae -- npx -y mcp-baepsae
+claude mcp add baepsae -- npx -y mcp-baepsae@latest
 
 # Codex CLI
-codex mcp add baepsae -- npx -y mcp-baepsae
+codex mcp add baepsae -- npx -y mcp-baepsae@latest
 
 # Gemini CLI
-gemini mcp add --scope user --transport stdio baepsae npx -y mcp-baepsae
+gemini mcp add --scope user --transport stdio baepsae npx -y mcp-baepsae@latest
 ```
 
 ### 로컬 빌드 사용

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Local MCP server for iOS Simulator and macOS app automation with a TypeScript MC
 
 ```bash
 # Run directly without installing
-npx mcp-baepsae
+npx mcp-baepsae@latest
 
 # Or install globally
 npm install -g mcp-baepsae
@@ -97,10 +97,10 @@ If you installed via npm instead of cloning the repo, use npx:
 
 ```bash
 # Claude Code
-claude mcp add baepsae -- npx -y mcp-baepsae
+claude mcp add baepsae -- npx -y mcp-baepsae@latest
 
 # Codex CLI
-codex mcp add baepsae -- npx -y mcp-baepsae
+codex mcp add baepsae -- npx -y mcp-baepsae@latest
 ```
 
 ### Automation flags
@@ -123,8 +123,8 @@ The installer supports multiple runtimes via `--runtime`:
 | Flag | Command | When to use |
 |---|---|---|
 | `--runtime node` (default) | `node dist/index.js` | Local source build |
-| `--runtime npx` | `npx -y mcp-baepsae` | npm registry, no global install |
-| `--runtime bunx` | `bunx mcp-baepsae` | Bun users |
+| `--runtime npx` | `npx -y mcp-baepsae@latest` | npm registry, no global install |
+| `--runtime bunx` | `bunx mcp-baepsae@latest` | Bun users |
 | `--runtime global` | `mcp-baepsae` | After `npm install -g mcp-baepsae` |
 
 ## Manual Setup (Fallback)
@@ -135,13 +135,13 @@ Use this when you do not want to run `scripts/install.sh`.
 
 ```bash
 # Claude Code
-claude mcp add baepsae -- npx -y mcp-baepsae
+claude mcp add baepsae -- npx -y mcp-baepsae@latest
 
 # Codex CLI
-codex mcp add baepsae -- npx -y mcp-baepsae
+codex mcp add baepsae -- npx -y mcp-baepsae@latest
 
 # Gemini CLI
-gemini mcp add --scope user --transport stdio baepsae npx -y mcp-baepsae
+gemini mcp add --scope user --transport stdio baepsae npx -y mcp-baepsae@latest
 ```
 
 ### Using local build

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -293,11 +293,11 @@ resolve_server_runtime_command() {
       ;;
     npx)
       SERVER_CMD="npx"
-      SERVER_CMD_ARGS=(-y "$SERVER_PACKAGE")
+      SERVER_CMD_ARGS=(-y "$SERVER_PACKAGE@latest")
       ;;
     bunx)
       SERVER_CMD="bunx"
-      SERVER_CMD_ARGS=("$SERVER_PACKAGE")
+      SERVER_CMD_ARGS=("$SERVER_PACKAGE@latest")
       ;;
     global)
       SERVER_CMD="$SERVER_PACKAGE"


### PR DESCRIPTION
## Summary
- `scripts/install.sh`의 npx/bunx 런타임에서 `mcp-baepsae@latest` 사용
- `README.md`, `README-KR.md`의 모든 npx/bunx 예시에 `@latest` 태그 추가
- npx 캐시에 이전 버전이 남아있어도 항상 최신 버전을 가져오도록 보장

Closes #6

## Test plan
- [x] `npm test` — 10개 테스트 전부 통과
- [ ] `npx mcp-baepsae@latest` 실행 시 최신 버전 확인