### PR TITLE
feat: add --version flag and improve build error messages

### DIFF
--- a/tests/mcp.contract.test.mjs
+++ b/tests/mcp.contract.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
@@ -252,4 +253,26 @@ test("describe_ui resolves native binary from different cwd (npx scenario)", asy
     assert.match(text, /baepsae-native/);
     assert.match(text, /describe-ui/);
   });
+});
+
+// --- CLI --version flag tests (Issue #17) ---
+
+test("--version flag prints version and exits", () => {
+  const output = execFileSync("node", ["dist/index.js", "--version"], {
+    cwd: projectRoot,
+    encoding: "utf8",
+    timeout: 5000,
+  }).trim();
+
+  assert.match(output, /^mcp-baepsae \d+\.\d+\.\d+$/);
+});
+
+test("-v flag prints version and exits", () => {
+  const output = execFileSync("node", ["dist/index.js", "-v"], {
+    cwd: projectRoot,
+    encoding: "utf8",
+    timeout: 5000,
+  }).trim();
+
+  assert.match(output, /^mcp-baepsae \d+\.\d+\.\d+$/);
 });


### PR DESCRIPTION
## Summary
- `--version` / `-v` CLI 플래그 지원 추가
- native binary 빌드 실패 시 환경별 가이드 메시지 개선 (non-macOS, no Swift, Swift available)
- --version 플래그 contract 테스트 2개 추가

Closes #17, Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)