### PR TITLE
Remove openclaw-specific wording from Accessibility guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The Swift native bridge (`baepsae-native`) uses macOS-specific frameworks (AppKi
 **Accessibility permission is required** for UI automation features (`describe_ui`, `tap` by ID).
 
 1. Open **System Settings** > **Privacy & Security** > **Accessibility**.
-2. Enable your terminal (Terminal, iTerm2, VSCode) or command runner (`node`, `openclaw`).
+2. Enable the MCP client app and terminal you actually use, and also the runtime process (`node`) if listed.
 3. If the app is missing, click `+` and add it manually.
 
 ## Install

--- a/native/Sources/Utils.swift
+++ b/native/Sources/Utils.swift
@@ -241,13 +241,16 @@ func ensureAccessibilityTrusted() throws {
     if AXIsProcessTrusted() {
         return
     }
+
     throw NativeError.commandFailed(
         """
         [Permission Denied] Accessibility access is required to read/control the Simulator UI.
 
+        Most commonly this happens because either the MCP client app or the terminal app running mcp-baepsae does not have Accessibility permission.
+
         Please enable it in macOS System Settings:
         1. Open 'System Settings' -> 'Privacy & Security' -> 'Accessibility'.
-        2. Find your terminal app (e.g. iTerm, Terminal, VSCode) or 'node'/'openclaw' in the list.
+        2. Find both the MCP client app and terminal app you used, and also the Node.js runtime ('node') in the list.
         3. Turn the switch ON.
         4. If it's already ON, try turning it OFF and ON again, or restart your terminal.
         """


### PR DESCRIPTION
### Motivation
- Remove an artifacted, product-specific reference (`openclaw`) from user-facing Accessibility guidance so the project remains provider-neutral and the instructions apply to any MCP client/runtime.

### Description
- Update the native runtime permission error in `native/Sources/Utils.swift` to replace `openclaw`-specific wording with neutral guidance that references the MCP client app, terminal, and the Node.js runtime (`node`).
- Update the `README.md` Permissions section to use neutral wording: instruct users to enable the MCP client app, their terminal, and the `node` runtime if present.
- Audit the repository for `openclaw` usages and remove the remaining occurrences found in the permission guidance.

### Testing
- Ran TypeScript build with `npm run build:ts`, which completed successfully.
- Verified there are no remaining `openclaw` matches with `rg -n "openclaw" README.md README-KR.md native/Sources src tests || true` which returned no results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ed58c2b64832294337f83db32287d)