### PR TITLE
chore: bump package version to 3.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-baepsae",
-  "version": "3.1.0",
+  "version": "3.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-baepsae",
-      "version": "3.1.0",
+      "version": "3.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-baepsae",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "mcpName": "io.github.oozoofrog/baepsae",
   "description": "Local MCP server for iOS Simulator and macOS app automation with a native Swift bridge",
   "author": "oozoofrog",


### PR DESCRIPTION
### Motivation
- Bump the npm package version to publish a patch release and keep package metadata consistent between `package.json` and `package-lock.json`.

### Description
- Updated the root `version` in `package.json` from `3.2.1` to `3.2.2` and aligned the root package metadata `version` in `package-lock.json` to `3.2.2`.

### Testing
- `npm run build:ts` completed successfully.  
- `node dist/index.js --version` printed `mcp-baepsae 3.2.2` as expected.  
- `node --test tests/unit.test.mjs` failed in the current Linux/container environment due to macOS/xcrun/native-binary expectations in the test suite (platform-dependent failures), not because of the version metadata change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698edaca74d08322af72430050abdc69)