### PR TITLE
fix: tighten iOS drag-drop gesture sequence

### DIFF
--- a/native/Sources/Commands/WindowCommands.swift
+++ b/native/Sources/Commands/WindowCommands.swift
@@ -71,7 +71,7 @@ func handleDragDrop(_ parsed: ParsedOptions) throws -> Int32 {
         throw NativeError.invalidArguments("drag-drop requires numeric start/end coordinates.")
     }
     let duration = try optionalDoubleOption("--duration", from: parsed) ?? 0.5
-    let holdDuration = try optionalDoubleOption("--hold-duration", from: parsed) ?? 0.5
+    let holdDuration = try optionalDoubleOption("--hold-duration", from: parsed) ?? 0.7
     let preDelay = try optionalDoubleOption("--pre-delay", from: parsed) ?? 0
     let postDelay = try optionalDoubleOption("--post-delay", from: parsed) ?? 0
     if preDelay > 0 {

--- a/native/Sources/Utils.swift
+++ b/native/Sources/Utils.swift
@@ -1106,6 +1106,22 @@ func sendDrag(from start: CGPoint, to end: CGPoint, holdDuration: Double, moveDu
     if holdDuration > 0 {
         Thread.sleep(forTimeInterval: holdDuration)
     }
+
+    // iOS drag & drop is often sensitive to the exact event sequence.
+    // A tiny initial move helps the simulator/app transition from the
+    // long-press state into an actual drag session before the full move.
+    let warmupOffset: CGFloat = 1.0
+    let warmupPoint = CGPoint(
+        x: start.x + (end.x >= start.x ? warmupOffset : -warmupOffset),
+        y: start.y + (end.y >= start.y ? warmupOffset : -warmupOffset)
+    )
+    postMouseEvent(type: .leftMouseDragged, point: warmupPoint)
+    if let moveDuration {
+        Thread.sleep(forTimeInterval: min(max(moveDuration / 20.0, 0.01), 0.05))
+    } else {
+        Thread.sleep(forTimeInterval: 0.03)
+    }
+
     let steps = 10
     for step in 1...steps {
         let progress = CGFloat(step) / CGFloat(steps)


### PR DESCRIPTION
### Summary
- increase the default drag/drop hold duration to better approximate iOS long-press initiation
- add a small warmup move so the gesture sequence becomes down -> hold -> slight move -> main move
- keep the change narrowly scoped to drag/drop gesture synthesis without expanding architecture or adding new drivers

### Test Plan
- [ ] `npm test` *(worker environment initially lacked TypeScript tooling)*
- [ ] `swift test --package-path native` *(existing permission-sensitive native tests still fail in the local environment)*

### Notes / Risks
- this is an experimental, minimal improvement intended to increase the chance of entering an iOS drag session, not a full guarantee across all apps/backends
- behavior may still vary by Simulator state, Accessibility permission, app-specific drag thresholds, and backend (`CGEvent` vs `IndigoHID`)
- if this is insufficient, the next step is likely more targeted simulator-specific experimentation rather than broader architecture changes in this PR

Closes #40
