### PR TITLE
fix: use simulator pasteboard for type_text

### DIFF
--- a/README-KR.md
+++ b/README-KR.md
@@ -262,10 +262,10 @@ npm run setup:mcp   # scripts/install.sh 실행 alias
 - `method: "auto"`는 다음처럼 해석됩니다.
   - 시뮬레이터 대상: `paste`
   - macOS 대상: `keyboard`
-- `method: "paste"`는 항상 클립보드 기반 붙여넣기 경로를 사용합니다.
+- `method: "paste"`는 시뮬레이터 대상에서는 simulator pasteboard를, macOS 대상에서는 host clipboard를 잠시 바꿨다가 복원하는 경로를 사용합니다.
 - `method: "keyboard"`는 항상 문자 단위 타이핑을 사용합니다.
 
-`paste`를 사용하면 도구가 클립보드를 잠시 덮어쓴 뒤 이전 내용을 복원합니다. 성공 응답에는 입력 소스, 대상 종류, 요청한 method, 실제 사용한 method, auto fallback이 함께 보고됩니다.
+`paste`를 사용하면 시뮬레이터 대상은 host clipboard를 건드리지 않고 simulator pasteboard를 갱신하며, macOS 대상은 host clipboard를 잠시 덮어쓴 뒤 복원합니다. 성공 응답에는 입력 소스, 대상 종류, 요청한 method, 실제 사용한 method, paste transport, auto fallback이 함께 보고됩니다.
 
 ## 사용 예시
 

--- a/README.md
+++ b/README.md
@@ -262,10 +262,10 @@ Target routing is explicit in the arguments: `udid` for simulator, `bundleId` / 
 - `method: "auto"` resolves to:
   - `paste` for simulator targets
   - `keyboard` for macOS targets
-- `method: "paste"` always uses the clipboard-backed paste path.
+- `method: "paste"` uses the simulator pasteboard for simulator targets and a temporary host clipboard replace/restore flow for macOS targets.
 - `method: "keyboard"` always types character-by-character.
 
-When `paste` is used, the tool temporarily overwrites the clipboard and restores the previous clipboard content after submission. Successful responses report the input source, target kind, requested method, used method, and any auto fallback that was applied.
+When `paste` is used, simulator targets update the simulator pasteboard without touching the host clipboard, while macOS targets temporarily overwrite the host clipboard and restore it after submission. Successful responses report the input source, target kind, requested method, used method, paste transport, and any auto fallback that was applied.
 
 ## Usage Examples
 

--- a/native/Sources/Commands/UICommands.swift
+++ b/native/Sources/Commands/UICommands.swift
@@ -338,7 +338,7 @@ func handleType(_ parsed: ParsedOptions) throws -> Int32 {
     }
 
     if usePaste {
-        try pasteText(text)
+        try pasteText(text, target: target)
     } else {
         let backend = resolveInputBackend(for: target)
         switch backend {
@@ -351,21 +351,36 @@ func handleType(_ parsed: ParsedOptions) throws -> Int32 {
     return 0
 }
 
-func pasteText(_ text: String) throws {
-    let pasteboard = NSPasteboard.general
-    let original = pasteboard.string(forType: .string)
+func pasteText(_ text: String, target: TargetApp) throws {
+    switch target {
+    case .simulator(let udid):
+        try setSimulatorPasteboard(text, udid: udid)
+        // Cmd+V: Command keycode=55, V keycode=9
+        sendKeyCombo(modifiers: [55], key: 9)
+        Thread.sleep(forTimeInterval: 0.2)
+    case .macApp:
+        let pasteboard = NSPasteboard.general
+        let original = pasteboard.string(forType: .string)
 
-    pasteboard.clearContents()
-    pasteboard.setString(text, forType: .string)
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
 
-    // Cmd+V: Command keycode=55, V keycode=9
-    sendKeyCombo(modifiers: [55], key: 9)
-    Thread.sleep(forTimeInterval: 0.15)
+        // Cmd+V: Command keycode=55, V keycode=9
+        sendKeyCombo(modifiers: [55], key: 9)
+        Thread.sleep(forTimeInterval: 0.15)
 
-    // Restore original clipboard content
-    pasteboard.clearContents()
-    if let original = original {
-        pasteboard.setString(original, forType: .string)
+        // Restore original clipboard content
+        pasteboard.clearContents()
+        if let original = original {
+            pasteboard.setString(original, forType: .string)
+        }
+    }
+}
+
+func setSimulatorPasteboard(_ text: String, udid: String) throws {
+    let status = try runProcess("/usr/bin/xcrun", ["simctl", "pbcopy", udid], stdinText: text)
+    if status != 0 {
+        throw NativeError.commandFailed("Failed to set simulator pasteboard (exit code \(status)).")
     }
 }
 

--- a/native/Sources/Utils.swift
+++ b/native/Sources/Utils.swift
@@ -133,10 +133,27 @@ func readFileText(_ path: String) throws -> String {
 // MARK: - Process Execution
 
 @discardableResult
-func runProcess(_ command: String, _ arguments: [String]) throws -> Int32 {
+func runProcess(_ command: String, _ arguments: [String], stdinText: String? = nil) throws -> Int32 {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: command)
     process.arguments = arguments
+    if let stdinText {
+        let pipe = Pipe()
+        process.standardInput = pipe
+        process.standardOutput = FileHandle.standardOutput
+        process.standardError = FileHandle.standardError
+        do {
+            try process.run()
+        } catch {
+            throw NativeError.commandFailed("Failed to launch process: \(command) \(arguments.joined(separator: " "))")
+        }
+        if let data = stdinText.data(using: .utf8) {
+            pipe.fileHandleForWriting.write(data)
+        }
+        pipe.fileHandleForWriting.closeFile()
+        process.waitUntilExit()
+        return process.terminationStatus
+    }
     process.standardInput = FileHandle.standardInput
     process.standardOutput = FileHandle.standardOutput
     process.standardError = FileHandle.standardError

--- a/src/tools/ui.ts
+++ b/src/tools/ui.ts
@@ -299,7 +299,14 @@ function buildTypeArgs(target: string[], params: TypeParams): { args: string[]; 
 function resolveTypeTextPolicy(
   params: TypeParams,
   target: UnifiedTargetParams
-): { requestedMethod: "auto" | "paste" | "keyboard"; usedMethod: "paste" | "keyboard"; targetKind: "simulator" | "macOS"; inputSource: "text" | "stdinText" | "file" } {
+): {
+  requestedMethod: "auto" | "paste" | "keyboard";
+  usedMethod: "paste" | "keyboard";
+  targetKind: "simulator" | "macOS";
+  inputSource: "text" | "stdinText" | "file";
+  pasteTransport: "simulator_pasteboard" | "host_clipboard" | null;
+  clipboardSideEffect: "none" | "temporary_replace_and_restore";
+} {
   const requestedMethod = params.method ?? "auto";
   const targetKind: "simulator" | "macOS" = target.udid ? "simulator" : "macOS";
   const usedMethod =
@@ -309,7 +316,15 @@ function resolveTypeTextPolicy(
         : "keyboard"
       : requestedMethod;
   const inputSource = params.stdinText !== undefined ? "stdinText" : params.file !== undefined ? "file" : "text";
-  return { requestedMethod, usedMethod, targetKind, inputSource };
+  const pasteTransport =
+    usedMethod === "paste"
+      ? targetKind === "simulator"
+        ? "simulator_pasteboard"
+        : "host_clipboard"
+      : null;
+  const clipboardSideEffect =
+    pasteTransport === "host_clipboard" ? "temporary_replace_and_restore" : "none";
+  return { requestedMethod, usedMethod, targetKind, inputSource, pasteTransport, clipboardSideEffect };
 }
 
 function buildSwipeArgs(target: string[], params: SwipeParams): string[] {
@@ -396,7 +411,7 @@ export function registerUITools(server: McpServer): void {
 
   server.tool(
     "type_text",
-    "Type text into the target app. auto resolves to paste on simulators and keyboard on macOS; paste temporarily uses the clipboard; keyboard types character-by-character.",
+    "Type text into the target app. auto resolves to paste on simulators and keyboard on macOS; simulator paste uses the simulator pasteboard, macOS paste temporarily uses the host clipboard; keyboard types character-by-character.",
     { ...unifiedTargetSchema, ...typeSchema },
     async (params) => {
       const validationError = validateTypeParams(params as TypeParams);
@@ -414,8 +429,15 @@ export function registerUITools(server: McpServer): void {
         `Used method: ${policy.usedMethod}`,
       ];
       if (policy.usedMethod === "paste") {
-        extraLines.push("Clipboard side effect: clipboard is temporarily replaced with the input text and restored after paste.");
+        if (policy.pasteTransport === "simulator_pasteboard") {
+          extraLines.push("Paste transport: simulator pasteboard.");
+          extraLines.push("Clipboard side effect: host clipboard is unchanged; the simulator pasteboard is updated for paste.");
+        } else {
+          extraLines.push("Paste transport: host clipboard.");
+          extraLines.push("Clipboard side effect: host clipboard is temporarily replaced with the input text and restored after paste.");
+        }
       } else {
+        extraLines.push("Paste transport: none.");
         extraLines.push("Clipboard side effect: none.");
       }
       if (policy.requestedMethod === "auto") {
@@ -431,7 +453,8 @@ export function registerUITools(server: McpServer): void {
             targetKind: policy.targetKind,
             requestedMethod: policy.requestedMethod,
             usedMethod: policy.usedMethod,
-            clipboardSideEffect: policy.usedMethod === "paste" ? "temporary_replace_and_restore" : "none",
+            pasteTransport: policy.pasteTransport,
+            clipboardSideEffect: policy.clipboardSideEffect,
             autoFallback: policy.requestedMethod === "auto" ? policy.usedMethod : null,
           },
         },

--- a/tests/mcp.contract.test.mjs
+++ b/tests/mcp.contract.test.mjs
@@ -111,7 +111,8 @@ test("type_text exposes policy metadata in machine-readable form", async () => {
     assert.equal(result.metadata?.targetKind, "simulator");
     assert.equal(result.metadata?.requestedMethod, "auto");
     assert.equal(result.metadata?.usedMethod, "paste");
-    assert.equal(result.metadata?.clipboardSideEffect, "temporary_replace_and_restore");
+    assert.equal(result.metadata?.pasteTransport, "simulator_pasteboard");
+    assert.equal(result.metadata?.clipboardSideEffect, "none");
     assert.equal(result.metadata?.autoFallback, "paste");
   });
 });

--- a/tests/unit.test.mjs
+++ b/tests/unit.test.mjs
@@ -658,9 +658,11 @@ test("type_text with method=paste includes --method flag", async () => {
     assert.match(text, /--method/);
     assert.match(text, /paste/);
     assert.match(text, /Used method: paste/);
-    assert.match(text, /Clipboard side effect: clipboard is temporarily replaced/);
+    assert.match(text, /Paste transport: simulator pasteboard\./);
+    assert.match(text, /Clipboard side effect: host clipboard is unchanged/);
     assert.equal(result.metadata?.usedMethod, "paste");
-    assert.equal(result.metadata?.clipboardSideEffect, "temporary_replace_and_restore");
+    assert.equal(result.metadata?.pasteTransport, "simulator_pasteboard");
+    assert.equal(result.metadata?.clipboardSideEffect, "none");
   });
 });
 
@@ -700,6 +702,7 @@ test("type_text without method does not include --method flag", async () => {
     assert.match(text, /Auto fallback: paste\./);
     assert.equal(result.metadata?.requestedMethod, "auto");
     assert.equal(result.metadata?.usedMethod, "paste");
+    assert.equal(result.metadata?.pasteTransport, "simulator_pasteboard");
     assert.equal(result.metadata?.autoFallback, "paste");
   });
 });


### PR DESCRIPTION
## Summary
- switch simulator `type_text` paste mode to use the simulator pasteboard via `xcrun simctl pbcopy`
- keep macOS target clipboard restore behavior unchanged
- add a shared native process execution helper for simulator clipboard writes

## Testing
- npm test
- npm run test:real

Closes #37