### PR TITLE
feat: add doctor readiness self-check

### DIFF
--- a/README-KR.md
+++ b/README-KR.md
@@ -238,7 +238,7 @@ npm run setup:mcp   # scripts/install.sh 실행 alias
 
 ## MCP 도구 구현 상태
 
-총 33개 도구가 end-to-end 구현 완료되었습니다.
+총 34개 도구가 end-to-end 구현 완료되었습니다.
 
 ### 공식 공개 MCP 표면: unified generic tools
 
@@ -251,7 +251,7 @@ npm run setup:mcp   # scripts/install.sh 실행 alias
 | System | `list_windows`, `activate_app`, `screenshot_app`, `right_click` |
 | iOS 시뮬레이터 전용 | `list_simulators`, `screenshot`, `record_video`, `stream_video`, `open_url`, `install_app`, `launch_app`, `terminate_app`, `uninstall_app`, `button`, `gesture` |
 | macOS / 시스템 | `list_apps`, `menu_action`, `get_focused_app`, `clipboard` |
-| 유틸리티 | `baepsae_help`, `baepsae_version` |
+| 유틸리티 | `baepsae_help`, `baepsae_version`, `doctor` |
 
 대상 라우팅은 인자로 명시합니다: simulator 는 `udid`, macOS 는 `bundleId` / `appName`.
 
@@ -290,6 +290,7 @@ tap({ udid: "...", label: "Home", all: true })
 ### 접근성 권한 체크리스트
 
 - 권한 대상은 보통 **target app** 이 아니라 **automation host/runtime process** 입니다.
+- 먼저 `doctor` 를 실행해서 host process, parent process, native binary, booted simulator availability, accessibility readiness 를 한 번에 확인하세요.
 - 오류 메시지에서 다음 항목을 먼저 확인하세요.
   - **current host process**
   - **parent process**

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ npm run setup:mcp   # Alias for scripts/install.sh
 
 ## MCP Tool Status
 
-33 tools implemented end-to-end.
+34 tools implemented end-to-end.
 
 ### Official public MCP surface: unified generic tools
 
@@ -251,7 +251,7 @@ The public API surface is intentionally single-scheme: use unified generic tools
 | System | `list_windows`, `activate_app`, `screenshot_app`, `right_click` |
 | Simulator-only | `list_simulators`, `screenshot`, `record_video`, `stream_video`, `open_url`, `install_app`, `launch_app`, `terminate_app`, `uninstall_app`, `button`, `gesture` |
 | macOS/system | `list_apps`, `menu_action`, `get_focused_app`, `clipboard` |
-| Utility | `baepsae_help`, `baepsae_version` |
+| Utility | `baepsae_help`, `baepsae_version`, `doctor` |
 
 Target routing is explicit in the arguments: `udid` for simulator, `bundleId` / `appName` for macOS.
 
@@ -317,6 +317,7 @@ screenshot_app({ bundleId: "com.apple.Safari" })
 ### Accessibility permission checklist
 
 - The permission target is usually the **automation host/runtime process**, not the target app.
+- Run `doctor` first to inspect host process, parent process, native binary, booted simulator availability, and accessibility readiness in one place.
 - Check the error message for:
   - **current host process**
   - **parent process**

--- a/native/Sources/Commands/SystemCommands.swift
+++ b/native/Sources/Commands/SystemCommands.swift
@@ -2,6 +2,37 @@ import AppKit
 import CoreGraphics
 import Foundation
 
+private struct DoctorReport: Codable {
+    struct Check: Codable {
+        let ok: Bool
+        let detail: String
+    }
+
+    let host: Check
+    let parent: Check
+    let nativeBinary: Check
+    let simulator: Check
+    let accessibility: Check
+}
+
+private func shellCapture(_ command: String, _ arguments: [String]) -> String? {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: command)
+    process.arguments = arguments
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = FileHandle.nullDevice
+    do {
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+    } catch {
+        return nil
+    }
+}
+
 func handleListApps(_ parsed: ParsedOptions) throws -> Int32 {
     let apps = NSWorkspace.shared.runningApplications.filter { $0.activationPolicy == .regular }
     for app in apps {
@@ -10,6 +41,61 @@ func handleListApps(_ parsed: ParsedOptions) throws -> Int32 {
         let pid = app.processIdentifier
         print("\(bundleId) | \(name) | \(pid)")
     }
+    return 0
+}
+
+func handleDoctor(_ parsed: ParsedOptions) throws -> Int32 {
+    var systemInfo = utsname()
+    uname(&systemInfo)
+    let machine = withUnsafePointer(to: &systemInfo.machine) {
+        $0.withMemoryRebound(to: CChar.self, capacity: 1) { String(cString: $0) }
+    }
+    let hostDetail = "\(ProcessInfo.processInfo.operatingSystemVersionString); arch=\(machine)"
+    let parentPid = getppid()
+    let parentDetail = shellCapture("/bin/ps", ["-p", String(parentPid), "-o", "pid=,ppid=,comm="]) ?? "unknown"
+
+    let nativeBinaryDetail = CommandLine.arguments.first ?? "baepsae-native"
+    let nativeBinaryOk = !nativeBinaryDetail.isEmpty
+
+    let simulatorAppRunning = NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.iphonesimulator").first != nil
+    let bootedDevicesOutput = shellCapture("/usr/bin/xcrun", ["simctl", "list", "devices", "booted"])
+    let bootedSimulatorAvailable = bootedDevicesOutput?.contains("(Booted)") ?? false
+    let simulatorDetail: String
+    if bootedSimulatorAvailable {
+        simulatorDetail = simulatorAppRunning
+            ? "Booted simulator available and Simulator app is running"
+            : "Booted simulator available"
+    } else if simulatorAppRunning {
+        simulatorDetail = "Simulator app is running, but no booted simulator was detected"
+    } else if bootedDevicesOutput == nil {
+        simulatorDetail = "Could not query booted simulators via simctl"
+    } else {
+        simulatorDetail = "Simulator app is not running and no booted simulator was detected"
+    }
+
+    let accessibilityTrusted = AXIsProcessTrusted()
+    let accessibilityDetail = accessibilityTrusted
+        ? "Accessibility permission granted"
+        : "Accessibility permission missing"
+
+    let report = DoctorReport(
+        host: .init(ok: true, detail: hostDetail),
+        parent: .init(ok: !parentDetail.isEmpty, detail: parentDetail),
+        nativeBinary: .init(ok: nativeBinaryOk, detail: nativeBinaryDetail),
+        simulator: .init(ok: bootedSimulatorAvailable, detail: simulatorDetail),
+        accessibility: .init(ok: accessibilityTrusted, detail: accessibilityDetail)
+    )
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    guard let data = try? encoder.encode(report), let json = String(data: data, encoding: .utf8) else {
+        throw NativeError.commandFailed("Failed to encode doctor report.")
+    }
+
+    print("Doctor check completed.")
+    print("host=\(report.host.ok ? "ok" : "warn") parent=\(report.parent.ok ? "ok" : "warn") native=\(report.nativeBinary.ok ? "ok" : "warn") simulator=\(report.simulator.ok ? "ok" : "warn") accessibility=\(report.accessibility.ok ? "ok" : "warn")")
+    print("")
+    print(json)
     return 0
 }
 

--- a/native/Sources/Utils.swift
+++ b/native/Sources/Utils.swift
@@ -26,6 +26,7 @@ let supportedCommands: Set<String> = [
     "gesture",
     "stream-video",
     "list-apps",
+    "doctor",
     "list-windows",
     "activate-app",
     "screenshot-app",

--- a/native/Sources/main.swift
+++ b/native/Sources/main.swift
@@ -13,6 +13,7 @@ func printHelp() {
       baepsae-native --version
       baepsae-native list-simulators
       baepsae-native list-apps
+      baepsae-native doctor
       baepsae-native describe-ui <TARGET> [--all] [--focus-id <ID>] [--root-element-id <ID>]
                      [--offset <N>] [--limit <M>] [--max-depth <N>]
                      [--role <ROLE>] [--visible-only] [--summary] [--output <path>]
@@ -103,6 +104,9 @@ func runParsed(_ parsed: ParsedOptions) throws -> Int32 {
 
     case "list-apps":
         return try handleListApps(parsed)
+
+    case "doctor":
+        return try handleDoctor(parsed)
 
     case "screenshot":
         return try handleScreenshot(parsed)

--- a/src/tool-manifest.ts
+++ b/src/tool-manifest.ts
@@ -51,6 +51,7 @@ export const TOOL_MANIFEST: ToolManifestEntry[] = [
 
   { name: "baepsae_help", category: "Utility", summary: "Show help." },
   { name: "baepsae_version", category: "Utility", summary: "Show server and native binary versions." },
+  { name: "doctor", category: "Utility", summary: "Run readiness self-checks for host process, native binary, simulator, and accessibility." },
 ];
 
 export const TOOL_CATEGORY_ORDER: ToolCategory[] = [

--- a/src/tools/info.ts
+++ b/src/tools/info.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { execFileSync } from "node:child_process";
 
 import {
   SERVER_NAME,
@@ -9,7 +10,29 @@ import {
   resolveNativeBinary,
   executeCommand,
   runNative,
+  tryResolveNativeBinaryPath,
 } from "../utils.js";
+
+function captureParentProcessDetail(): string {
+  try {
+    return execFileSync("/bin/ps", ["-p", String(process.ppid), "-o", "pid=,ppid=,comm="], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+function extractJsonObject(text: string): unknown | null {
+  const match = text.match(/(\{[\s\S]*\})\s*$/);
+  if (!match) return null;
+  try {
+    return JSON.parse(match[1]);
+  } catch {
+    return null;
+  }
+}
 
 export function registerInfoTools(server: McpServer): void {
   server.tool(
@@ -45,7 +68,10 @@ export function registerInfoTools(server: McpServer): void {
         "- list_simulators, screenshot, record_video, stream_video, open_url, install_app, launch_app, terminate_app, uninstall_app, button, gesture",
         "",
         "macOS/system:",
-        "- list_apps, menu_action, get_focused_app, clipboard, baepsae_help, baepsae_version",
+        "- list_apps, menu_action, get_focused_app, clipboard",
+        "",
+        "Utility:",
+        "- baepsae_help, baepsae_version, doctor",
         "",
         "Accessibility tip:",
         "- launch_app -> analyze_ui/query_ui -> tap(id/label)",
@@ -85,6 +111,81 @@ export function registerInfoTools(server: McpServer): void {
       isError: false,
     };
   });
+
+  server.tool(
+    "doctor",
+    "Run readiness self-checks for host process, parent process, native binary, booted simulator availability, and accessibility permission.",
+    {},
+    async () => {
+      const host = {
+        ok: true,
+        detail: `${process.platform} ${process.arch}; node=${process.version}; pid=${process.pid}; ppid=${process.ppid}`,
+      };
+      const parent = {
+        ok: true,
+        detail: captureParentProcessDetail(),
+      };
+      const nativeBinary = tryResolveNativeBinaryPath();
+
+      let nativeCheck: { ok: boolean; detail: string } = nativeBinary.ok
+        ? { ok: true, detail: nativeBinary.path }
+        : { ok: false, detail: nativeBinary.error };
+      let simulator = { ok: false, detail: "native doctor not executed" };
+      let accessibility = { ok: false, detail: "native doctor not executed" };
+
+      if (nativeBinary.ok) {
+        const doctorResult = await runNative(["doctor"]);
+        const parsed = doctorResult.content
+          .filter((item) => item.type === "text")
+          .map((item) => item.text)
+          .join("\n");
+        const json = extractJsonObject(parsed);
+        if (json && typeof json === "object") {
+          const report = json as Record<string, { ok?: boolean; detail?: string }>;
+          simulator = {
+            ok: Boolean(report.simulator?.ok),
+            detail: report.simulator?.detail ?? "unknown",
+          };
+          accessibility = {
+            ok: Boolean(report.accessibility?.ok),
+            detail: report.accessibility?.detail ?? "unknown",
+          };
+          nativeCheck = {
+            ok: true,
+            detail: `${nativeBinary.path} (doctor ok)`,
+          };
+        } else {
+          nativeCheck = {
+            ok: false,
+            detail: `${nativeBinary.path} (doctor output could not be parsed)`,
+          };
+        }
+      }
+
+      const report = {
+        host,
+        parent,
+        nativeBinary: nativeCheck,
+        simulator,
+        accessibility,
+      };
+      const lines = [
+        "Doctor check completed.",
+        `host: ${host.ok ? "ok" : "warn"} — ${host.detail}`,
+        `parent: ${parent.ok ? "ok" : "warn"} — ${parent.detail}`,
+        `native binary: ${nativeCheck.ok ? "ok" : "warn"} — ${nativeCheck.detail}`,
+        `simulator: ${simulator.ok ? "ok" : "warn"} — ${simulator.detail}`,
+        `accessibility: ${accessibility.ok ? "ok" : "warn"} — ${accessibility.detail}`,
+        "",
+        JSON.stringify(report, null, 2),
+      ];
+
+      return {
+        content: [{ type: "text", text: lines.join("\n") }],
+        isError: !(host.ok && parent.ok && nativeCheck.ok && simulator.ok && accessibility.ok),
+      };
+    }
+  );
 
   server.tool(
     "list_apps",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,7 @@ export const BAEPSAE_SUBCOMMANDS = [
   "search-ui",
   "list-simulators",
   "list-apps",
+  "doctor",
   "tap",
   "tap-tab",
   "type",
@@ -460,4 +461,12 @@ export async function runNative(
     }
   }
   return result;
+}
+
+export function tryResolveNativeBinaryPath(): { ok: true; path: string } | { ok: false; error: string } {
+  try {
+    return { ok: true, path: resolveNativeBinary() };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
 }

--- a/tests/mcp.contract.test.mjs
+++ b/tests/mcp.contract.test.mjs
@@ -116,6 +116,20 @@ test("type_text exposes policy metadata in machine-readable form", async () => {
   });
 });
 
+test("doctor returns structured readiness report", async () => {
+  await withClient(async (client) => {
+    const result = await client.callTool({ name: "doctor", arguments: {} });
+    const text = result.content
+      .filter((item) => item.type === "text")
+      .map((item) => item.text)
+      .join("\n");
+
+    assert.match(text, /Doctor check completed\./);
+    assert.match(text, /"host":/);
+    assert.match(text, /"accessibility":/);
+  });
+});
+
 test("tap validates coordinate pair before native invocation", async () => {
   await withClient(async (client) => {
     const result = await client.callTool({

--- a/tests/unit.test.mjs
+++ b/tests/unit.test.mjs
@@ -59,7 +59,7 @@ async function withClient(run, envOverrides = {}) {
 // Section 1: Tool registry completeness
 // ===========================================================================
 
-test("tool registry lists all 33 expected MCP tools", async () => {
+  test("tool registry lists all 34 expected MCP tools", async () => {
   await withClient(async (client) => {
     const result = await client.listTools();
     const names = new Set(result.tools.map((t) => t.name));
@@ -67,6 +67,7 @@ test("tool registry lists all 33 expected MCP tools", async () => {
     const allExpected = [
       "baepsae_help",
       "baepsae_version",
+      "doctor",
       "list_simulators",
       "list_apps",
       "open_url",


### PR DESCRIPTION
## Summary
- add a `doctor` MCP tool plus native `doctor` subcommand for readiness self-checks
- report host/parent process context, native binary availability, simulator availability, and accessibility readiness
- include doctor in help/manifest/docs and cover it with contract/unit tests

## Testing
- npm test
- npm run test:real

Closes #56