### PR TITLE
fix: clarify video capture semantics

### DIFF
--- a/src/tools/media.ts
+++ b/src/tools/media.ts
@@ -6,11 +6,15 @@ import { pushOption, ensureOutputPath, runNative, runSimctl } from "../utils.js"
 export function registerMediaTools(server: McpServer): void {
   server.tool(
     "stream_video",
-    "Stream simulator frames.",
+    "Capture a time-bounded simulator clip through the native stream-video shim.",
     {
       udid: z.string().min(1).describe("Simulator UDID"),
-      output: z.string().optional().describe("Destination output path"),
-      durationSeconds: z.number().positive().optional().describe("Capture duration in seconds"),
+      output: z.string().optional().describe("Destination MOV file path for the captured clip"),
+      durationSeconds: z
+        .number()
+        .positive()
+        .optional()
+        .describe("Requested clip duration in seconds (currently used as a timeout budget)"),
     },
     async (params) => {
       const args = ["stream-video", "--udid", params.udid];
@@ -27,7 +31,18 @@ export function registerMediaTools(server: McpServer): void {
           timeoutMs: Math.max(15_000, Math.round((durationSeconds + 15) * 1000)),
         },
         {
-          extraLines: [`Capture duration: ${durationSeconds}s`, `Output file: ${resolvedOutput}`],
+          extraLines: [
+            "Capture mode: stream-video shim.",
+            "Backend: simctl recordVideo (current implementation).",
+            `Requested duration: ${durationSeconds}s`,
+            `Output file: ${resolvedOutput}`,
+          ],
+          metadata: {
+            captureMode: "stream_video_shim",
+            backend: "simctl.recordVideo",
+            requestedDurationSeconds: durationSeconds,
+            outputPath: resolvedOutput,
+          },
         }
       );
     }
@@ -35,11 +50,15 @@ export function registerMediaTools(server: McpServer): void {
 
   server.tool(
     "record_video",
-    "Record simulator display.",
+    "Record simulator display directly with simctl recordVideo.",
     {
       udid: z.string().min(1).describe("Simulator UDID"),
       output: z.string().optional().describe("Output MOV file path"),
-      durationSeconds: z.number().positive().optional().describe("Recording duration in seconds (default: 10)"),
+      durationSeconds: z
+        .number()
+        .positive()
+        .optional()
+        .describe("Requested recording duration in seconds (default: 10)"),
     },
     async (params) => {
       const durationSeconds = params.durationSeconds ?? 10;
@@ -47,7 +66,8 @@ export function registerMediaTools(server: McpServer): void {
       const resolvedOutput = await ensureOutputPath(outputPath);
 
       const extraLines = [
-        `Recording duration: ${durationSeconds}s`,
+        "Capture mode: direct simctl recordVideo.",
+        `Requested duration: ${durationSeconds}s`,
         `Output file: ${resolvedOutput}`,
       ];
 
@@ -59,6 +79,12 @@ export function registerMediaTools(server: McpServer): void {
         {
           timeoutIsExpected: true,
           extraLines,
+          metadata: {
+            captureMode: "record_video_direct",
+            backend: "simctl.recordVideo",
+            requestedDurationSeconds: durationSeconds,
+            outputPath: resolvedOutput,
+          },
         }
       );
     }

--- a/tests/unit.test.mjs
+++ b/tests/unit.test.mjs
@@ -1262,56 +1262,107 @@ test("screenshot_app forwards output option", async () => {
 });
 
 // ===========================================================================
-// Section 22: record_video extra lines and timeout
+// Section 22: record_video capture semantics
 // ===========================================================================
 
-test("record_video output includes recording duration and output file", async () => {
+test("record_video output includes capture mode, requested duration, and output file", async () => {
   await withClient(async (client) => {
+    const outputPath = ".tmp-test-artifacts/test-record.mov";
     const result = await client.callTool({
       name: "record_video",
       arguments: {
         udid: "00000000-0000-0000-0000-000000000000",
         durationSeconds: 2,
-        output: ".tmp-test-artifacts/test-record.mov",
+        output: outputPath,
       },
     });
     const text = extractText(result);
-    assert.match(text, /Recording duration: 2s/);
+    assert.match(text, /Capture mode: direct simctl recordVideo\./);
+    assert.match(text, /Requested duration: 2s/);
     assert.match(text, /Output file:.*test-record\.mov/);
+    assert.equal(result.metadata?.captureMode, "record_video_direct");
+    assert.equal(result.metadata?.backend, "simctl.recordVideo");
+    assert.equal(result.metadata?.requestedDurationSeconds, 2);
+    assert.equal(result.metadata?.outputPath, path.resolve(outputPath));
   });
 });
 
 test("record_video defaults to 10s duration when not specified", async () => {
   await withClient(async (client) => {
+    const outputPath = ".tmp-test-artifacts/test-record-default.mov";
     const result = await client.callTool({
       name: "record_video",
       arguments: {
         udid: "00000000-0000-0000-0000-000000000000",
-        output: ".tmp-test-artifacts/test-record-default.mov",
+        output: outputPath,
       },
     });
     const text = extractText(result);
-    assert.match(text, /Recording duration: 10s/);
+    assert.match(text, /Capture mode: direct simctl recordVideo\./);
+    assert.match(text, /Requested duration: 10s/);
+    assert.equal(result.metadata?.captureMode, "record_video_direct");
+    assert.equal(result.metadata?.requestedDurationSeconds, 10);
+    assert.equal(result.metadata?.outputPath, path.resolve(outputPath));
   });
 });
 
 // ===========================================================================
-// Section 23: stream_video extra lines
+// Section 23: stream_video capture semantics
 // ===========================================================================
 
-test("stream_video output includes capture duration and output file", async () => {
+test("stream_video output explains the current shim and output file", async () => {
   await withClient(async (client) => {
+    const outputPath = ".tmp-test-artifacts/test-stream.mov";
     const result = await client.callTool({
       name: "stream_video",
       arguments: {
         udid: "00000000-0000-0000-0000-000000000000",
         durationSeconds: 2,
-        output: ".tmp-test-artifacts/test-stream.mov",
+        output: outputPath,
       },
     });
     const text = extractText(result);
-    assert.match(text, /Capture duration: 2s/);
+    assert.match(text, /Capture mode: stream-video shim\./);
+    assert.match(text, /Backend: simctl recordVideo \(current implementation\)\./);
+    assert.match(text, /Requested duration: 2s/);
     assert.match(text, /Output file:.*test-stream\.mov/);
+    assert.equal(result.metadata?.captureMode, "stream_video_shim");
+    assert.equal(result.metadata?.backend, "simctl.recordVideo");
+    assert.equal(result.metadata?.requestedDurationSeconds, 2);
+    assert.equal(result.metadata?.outputPath, path.resolve(outputPath));
+  });
+});
+
+test("stream_video and record_video expose different capture semantics", async () => {
+  await withClient(async (client) => {
+    const streamOutput = ".tmp-test-artifacts/test-stream-diff.mov";
+    const recordOutput = ".tmp-test-artifacts/test-record-diff.mov";
+
+    const streamResult = await client.callTool({
+      name: "stream_video",
+      arguments: {
+        udid: "00000000-0000-0000-0000-000000000000",
+        durationSeconds: 1,
+        output: streamOutput,
+      },
+    });
+    const recordResult = await client.callTool({
+      name: "record_video",
+      arguments: {
+        udid: "00000000-0000-0000-0000-000000000000",
+        durationSeconds: 1,
+        output: recordOutput,
+      },
+    });
+
+    assert.equal(streamResult.metadata?.captureMode, "stream_video_shim");
+    assert.equal(recordResult.metadata?.captureMode, "record_video_direct");
+    assert.notEqual(streamResult.metadata?.captureMode, recordResult.metadata?.captureMode);
+
+    const streamText = extractText(streamResult);
+    const recordText = extractText(recordResult);
+    assert.match(streamText, /Capture mode: stream-video shim\./);
+    assert.match(recordText, /Capture mode: direct simctl recordVideo\./);
   });
 });
 


### PR DESCRIPTION
## Summary
- distinguish `stream_video` from `record_video` with clearer descriptions, capture-mode messaging, and machine-readable metadata
- document the current `stream_video` shim behavior instead of implying a true live stream implementation
- add unit coverage that locks the semantic difference between the two tools

## Testing
- npm ci
- npm test
- node --test tests/unit.test.mjs

Closes #52