### PR TITLE
feat: add selector retry support to run_steps

### DIFF
--- a/src/tools/workflow.ts
+++ b/src/tools/workflow.ts
@@ -24,6 +24,8 @@ type WorkflowStep = {
   double?: boolean;
   preDelay?: number;
   postDelay?: number;
+  waitTimeout?: number;
+  pollInterval?: number;
   text?: string;
   stdinText?: string;
   file?: string;
@@ -50,6 +52,8 @@ type WorkflowStepResult = {
   durationMs: number;
   message: string;
   nativeText?: string;
+  attempts?: number;
+  retryableFailure?: boolean;
 };
 
 const workflowStepSchema = z.object({
@@ -62,6 +66,8 @@ const workflowStepSchema = z.object({
   double: z.boolean().optional().describe("Send double-click instead of single click"),
   preDelay: z.number().optional().describe("Delay before tap or swipe in seconds"),
   postDelay: z.number().optional().describe("Delay after tap or swipe in seconds"),
+  waitTimeout: z.number().min(0).optional().describe("Selector wait/retry window for tap steps, in milliseconds"),
+  pollInterval: z.number().min(1).optional().describe("Polling interval for selector wait/retry, in milliseconds"),
   text: z.string().optional().describe("Text argument"),
   stdinText: z.string().optional().describe("Text piped to stdin mode"),
   file: z.string().optional().describe("Path for file input"),
@@ -207,6 +213,10 @@ function buildSwipeArgs(targetArgs: string[], step: WorkflowStep): string[] {
   return args;
 }
 
+function sleepMs(durationMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, durationMs));
+}
+
 function indent(text: string, prefix = "  "): string {
   return text
     .split(/\r?\n/)
@@ -220,6 +230,32 @@ function extractText(result: ToolTextResult): string {
     .map((item) => item.text)
     .join("\n")
     .trim();
+}
+
+function hasSelectorTap(step: WorkflowStep): boolean {
+  return step.tool === "tap" && (step.id !== undefined || step.label !== undefined);
+}
+
+function isRetryableSelectorTapFailure(step: WorkflowStep, result: ToolTextResult): boolean {
+  if (!hasSelectorTap(step) || !result.isError || !result.error) return false;
+
+  const error = result.error;
+  if (error.source !== "native") return false;
+  if (error.category === "validation" || error.category === "permission" || error.category === "unsupported" || error.category === "environment") {
+    return false;
+  }
+
+  const code = error.code.toLowerCase();
+  const text = `${error.message}\n${extractText(result)}`.toLowerCase();
+  return (
+    code.includes("selector_not_found") ||
+    (error.category === "availability" && code === "availability.target_unavailable" && text.includes("no accessibility element matched"))
+  );
+}
+
+function formatAttemptMessage(baseMessage: string, attempts: number): string {
+  if (attempts <= 1) return baseMessage;
+  return `${baseMessage} after ${attempts} attempt(s)`;
 }
 
 function formatStepLabel(step: WorkflowStep): string {
@@ -260,16 +296,49 @@ async function executeWorkflowStep(
     case "tap": {
       const validationError = validateTapStep(step, stepIndex);
       if (validationError) return validationError;
-      const result = await runNative(buildTapArgs(targetArgs!, step));
-      return {
-        index: stepIndex,
-        total,
-        tool: step.tool,
-        status: result.isError ? "failed" : "success",
-        durationMs: Date.now() - startedAt,
-        message: result.isError ? extractText(result) || `${stepLabel} failed` : `${stepLabel} completed`,
-        nativeText: result.isError ? extractText(result) : undefined,
-      };
+      const waitTimeoutMs = step.waitTimeout ?? 0;
+      const pollIntervalMs = step.pollInterval ?? 250;
+      const shouldWaitForSelector = hasSelectorTap(step) && waitTimeoutMs > 0;
+      const deadlineMs = startedAt + waitTimeoutMs;
+
+      let attempts = 0;
+
+      while (true) {
+        attempts += 1;
+        const result = await runNative(buildTapArgs(targetArgs!, step));
+        if (!result.isError) {
+          return {
+            index: stepIndex,
+            total,
+            tool: step.tool,
+            status: "success",
+            durationMs: Date.now() - startedAt,
+            message: formatAttemptMessage(`${stepLabel} completed`, attempts),
+            attempts,
+          };
+        }
+
+        const retryableFailure = isRetryableSelectorTapFailure(step, result);
+        if (!shouldWaitForSelector || !retryableFailure || Date.now() >= deadlineMs) {
+          const text = extractText(result);
+          return {
+            index: stepIndex,
+            total,
+            tool: step.tool,
+            status: "failed",
+            durationMs: Date.now() - startedAt,
+            message: formatAttemptMessage(text || `${stepLabel} failed`, attempts),
+            nativeText: text || undefined,
+            attempts,
+            retryableFailure: result.error?.retryable ?? false,
+          };
+        }
+
+        const remainingMs = deadlineMs - Date.now();
+        if (remainingMs > 0) {
+          await sleepMs(Math.min(Math.max(1, pollIntervalMs), remainingMs));
+        }
+      }
     }
     case "type_text": {
       const validationError = validateTypeStep(step, stepIndex);
@@ -284,6 +353,8 @@ async function executeWorkflowStep(
         durationMs: Date.now() - startedAt,
         message: result.isError ? extractText(result) || `${stepLabel} failed` : `${stepLabel} completed`,
         nativeText: result.isError ? extractText(result) : undefined,
+        attempts: 1,
+        retryableFailure: result.error?.retryable ?? false,
       };
     }
     case "key": {
@@ -298,6 +369,8 @@ async function executeWorkflowStep(
         durationMs: Date.now() - startedAt,
         message: result.isError ? extractText(result) || `${stepLabel} failed` : `${stepLabel} completed`,
         nativeText: result.isError ? extractText(result) : undefined,
+        attempts: 1,
+        retryableFailure: result.error?.retryable ?? false,
       };
     }
     case "swipe": {
@@ -312,6 +385,8 @@ async function executeWorkflowStep(
         durationMs: Date.now() - startedAt,
         message: result.isError ? extractText(result) || `${stepLabel} failed` : `${stepLabel} completed`,
         nativeText: result.isError ? extractText(result) : undefined,
+        attempts: 1,
+        retryableFailure: result.error?.retryable ?? false,
       };
     }
     case "sleep": {
@@ -324,6 +399,8 @@ async function executeWorkflowStep(
         status: "success",
         durationMs: Date.now() - startedAt,
         message: `slept for ${durationSeconds}s`,
+        attempts: 1,
+        retryableFailure: false,
       };
     }
   }
@@ -333,10 +410,11 @@ function buildWorkflowSummary(
   stepResults: WorkflowStepResult[],
   continueOnError: boolean,
   targetLabel: string,
-): { text: string; failedCount: number; successCount: number; skippedCount: number } {
+): { text: string; failedCount: number; successCount: number; skippedCount: number; retryableFailureCount: number } {
   const successCount = stepResults.filter((step) => step.status === "success").length;
   const failedCount = stepResults.filter((step) => step.status === "failed").length;
   const skippedCount = stepResults.filter((step) => step.status === "skipped").length;
+  const retryableFailureCount = stepResults.filter((step) => step.status === "failed" && step.retryableFailure).length;
 
   const lines = [
     `Workflow target: ${targetLabel}`,
@@ -357,7 +435,7 @@ function buildWorkflowSummary(
     `Final summary: ${successCount} succeeded, ${failedCount} failed, ${skippedCount} skipped. Status: ${failedCount > 0 ? "failure" : "success"}.`,
   );
 
-  return { text: lines.join("\n"), failedCount, successCount, skippedCount };
+  return { text: lines.join("\n"), failedCount, successCount, skippedCount, retryableFailureCount };
 }
 
 export function registerWorkflowTools(server: McpServer): void {
@@ -432,7 +510,7 @@ export function registerWorkflowTools(server: McpServer): void {
               code: summary.failedCount > 1 ? "workflow.steps_failed" : "workflow.step_failed",
               category: "execution",
               message: `${summary.failedCount} workflow step(s) failed.`,
-              retryable: true,
+              retryable: summary.failedCount === summary.retryableFailureCount,
             })
           : undefined,
         metadata: {

--- a/tests/mcp.contract.test.mjs
+++ b/tests/mcp.contract.test.mjs
@@ -71,20 +71,62 @@ function extractText(result) {
     .join("\n");
 }
 
-function createFakeNativeBinary(failCommands = []) {
+function countMatches(text, pattern) {
+  const matches = text.match(pattern);
+  return matches ? matches.length : 0;
+}
+
+function createFakeNativeBinary(options = {}) {
+  const {
+    failCommands = [],
+    selectorFailuresBeforeSuccess = 0,
+    selectorFailureMode = "selector_not_found",
+  } = Array.isArray(options) ? { failCommands: options } : options;
   const dir = mkdtempSync(path.join(os.tmpdir(), "baepsae-workflow-contract-"));
   const binaryPath = path.join(dir, "fake-baepsae-native.sh");
   const logPath = path.join(dir, "native.log");
+  const selectorStatePath = path.join(dir, "selector.state");
+  const selectorNotFoundPayload =
+    'BAEPSAE_ERROR {"code":"availability.target_unavailable","category":"availability","retryable":true,"source":"native","message":"No accessibility element matched selector.","nativeCode":"command_failed"}';
+  const permissionPayload =
+    'BAEPSAE_ERROR {"code":"permission.accessibility_required","category":"permission","retryable":false,"source":"native","message":"Permission Denied: Accessibility access is required.","nativeCode":"command_failed"}';
   const script = [
     "#!/usr/bin/env bash",
     "set -euo pipefail",
     'log_file="${BAEPSAE_FAKE_NATIVE_LOG:?missing log file}"',
     'fail_commands="${BAEPSAE_FAKE_NATIVE_FAIL_COMMANDS:-}"',
+    'selector_failures="${BAEPSAE_FAKE_NATIVE_SELECTOR_FAILURES_BEFORE_SUCCESS:-0}"',
+    'selector_failure_mode="${BAEPSAE_FAKE_NATIVE_SELECTOR_FAILURE_MODE:-selector_not_found}"',
+    'selector_state_file="${BAEPSAE_FAKE_NATIVE_SELECTOR_STATE_FILE:-}"',
     'cmd="${1:-}"',
     'printf \'%s\\n\' "$*" >> "$log_file"',
     'if [[ "$cmd" == "--version" ]]; then',
     '  echo "baepsae-native 0.0.0"',
     "  exit 0",
+    "fi",
+    'if [[ -n "$selector_state_file" ]]; then',
+    '  touch "$selector_state_file" 2>/dev/null || true',
+    "fi",
+    'if [[ "$cmd" == "tap" && ( " $* " == *" --id "* || " $* " == *" --label "* ) ]]; then',
+    '  if [[ -z "$selector_state_file" ]]; then',
+    '    selector_state_file="${BAEPSAE_FAKE_NATIVE_LOG}.selector.state"',
+    "  fi",
+    '  current_failures=0',
+    '  if [[ -f "$selector_state_file" ]]; then',
+    '    current_failures="$(cat "$selector_state_file" 2>/dev/null || echo 0)"',
+    "  fi",
+    '  if (( current_failures < selector_failures )); then',
+    '    next_failures=$((current_failures + 1))',
+    '    printf \'%s\\n\' "$next_failures" > "$selector_state_file"',
+    '    if [[ "$selector_failure_mode" == "permission_denied" ]]; then',
+    `      printf '%s\\n' '${permissionPayload}' >&2`,
+    '      printf \'Permission Denied: Accessibility access is required.\\n\' >&2',
+    "      exit 1",
+    "    fi",
+    `    printf '%s\\n' '${selectorNotFoundPayload}' >&2`,
+    '    printf \'No accessibility element matched selector.\\n\' >&2',
+    "    exit 1",
+    "  fi",
     "fi",
     'if [[ " $fail_commands " == *" $cmd "* ]]; then',
     '  echo "forced failure for $cmd" >&2',
@@ -94,11 +136,12 @@ function createFakeNativeBinary(failCommands = []) {
   ].join("\n");
   writeFileSync(binaryPath, script);
   chmodSync(binaryPath, 0o755);
+  writeFileSync(selectorStatePath, "0\n");
   return { dir, binaryPath, logPath };
 }
 
-async function withFakeNativeClient(run, failCommands = []) {
-  const fake = createFakeNativeBinary(failCommands);
+async function withFakeNativeClient(run, failCommands = [], fakeOptions = {}) {
+  const fake = createFakeNativeBinary({ ...fakeOptions, failCommands });
   try {
     return await withClient(
       (client) => run(client, fake),
@@ -106,6 +149,9 @@ async function withFakeNativeClient(run, failCommands = []) {
         BAEPSAE_NATIVE_PATH: fake.binaryPath,
         BAEPSAE_FAKE_NATIVE_LOG: fake.logPath,
         BAEPSAE_FAKE_NATIVE_FAIL_COMMANDS: failCommands.join(" "),
+        BAEPSAE_FAKE_NATIVE_SELECTOR_FAILURES_BEFORE_SUCCESS: String(fakeOptions.selectorFailuresBeforeSuccess ?? 0),
+        BAEPSAE_FAKE_NATIVE_SELECTOR_FAILURE_MODE: fakeOptions.selectorFailureMode ?? "selector_not_found",
+        BAEPSAE_FAKE_NATIVE_SELECTOR_STATE_FILE: path.join(fake.dir, "selector.state"),
       },
     );
   } finally {
@@ -149,7 +195,7 @@ test("baepsae_version returns non-error response", async () => {
 });
 
 test("type_text exposes policy metadata in machine-readable form", async () => {
-  await withClient(async (client) => {
+  await withFakeNativeClient(async (client) => {
     const result = await client.callTool({
       name: "type_text",
       arguments: {
@@ -267,6 +313,66 @@ test("run_steps can continue after failures when continueOnError is enabled", as
     assert.match(log, /key 41/);
     assert.match(log, /swipe .*10 .*20/);
   }, ["key"]);
+});
+
+test("run_steps retries selector taps until the element appears", async () => {
+  await withFakeNativeClient(
+    async (client, fake) => {
+      const result = await client.callTool({
+        name: "run_steps",
+        arguments: {
+          udid: "00000000-0000-0000-0000-000000000000",
+          steps: [
+            { tool: "tap", id: "login-button", waitTimeout: 400, pollInterval: 50 },
+            { tool: "sleep", duration: 0.01 },
+          ],
+        },
+      });
+
+      assert.equal(result.isError ?? false, false);
+      const text = extractText(result);
+      assert.match(text, /Execution policy: fail-fast/);
+      assert.match(text, /Step 1\/2 .*tap .*success/);
+      assert.match(text, /Step 2\/2 .*sleep .*success/);
+      assert.match(text, /completed after 3 attempt\(s\)/);
+      assert.match(text, /Final summary: 2 succeeded, 0 failed, 0 skipped\./);
+
+      const log = readFileSync(fake.logPath, "utf8");
+      assert.equal(countMatches(log, /^tap .*login-button.*$/gm), 3);
+    },
+    [],
+    { selectorFailuresBeforeSuccess: 2 },
+  );
+});
+
+test("run_steps treats permission failures as immediate even with selector retry configured", async () => {
+  await withFakeNativeClient(
+    async (client, fake) => {
+      const result = await client.callTool({
+        name: "run_steps",
+        arguments: {
+          udid: "00000000-0000-0000-0000-000000000000",
+          continueOnError: true,
+          steps: [
+            { tool: "tap", id: "danger-button", waitTimeout: 120, pollInterval: 20 },
+            { tool: "sleep", duration: 0.01 },
+          ],
+        },
+      });
+
+      assert.equal(result.isError ?? false, true);
+      const text = extractText(result);
+      assert.match(text, /Execution policy: continue_on_error/);
+      assert.match(text, /Step 1\/2 .*tap .*failed/);
+      assert.match(text, /Step 2\/2 .*sleep .*success/);
+      assert.match(text, /Final summary: 1 succeeded, 1 failed, 0 skipped\./);
+
+      const log = readFileSync(fake.logPath, "utf8");
+      assert.equal(countMatches(log, /^tap .*danger-button.*$/gm), 1);
+    },
+    [],
+    { selectorFailureMode: "permission_denied", selectorFailuresBeforeSuccess: 1 },
+  );
 });
 
 test("analyze_ui call is routed to native layer (simulator target)", async () => {


### PR DESCRIPTION
## Summary
- add selector tap wait/retry support to `run_steps` with `waitTimeout` and `pollInterval`
- retry only selector-not-found style failures while keeping validation/permission/environment failures immediate
- extend fake-native contract coverage for retry success and immediate permission failure cases

## Testing
- npm test
- npm run test:real

Closes #51