### PR TITLE
feat: add simulator auxiliary container fallback

### DIFF
--- a/native/Sources/Commands/UICommands.swift
+++ b/native/Sources/Commands/UICommands.swift
@@ -9,6 +9,7 @@ func handleDescribeUI(_ parsed: ParsedOptions) throws -> Int32 {
 
     let appRoot = try accessibilityRootElement(for: target)
     var targetRoot = appRoot
+    var usedSimulatorContentScope = false
 
     switch target {
     case .simulator:
@@ -16,6 +17,7 @@ func handleDescribeUI(_ parsed: ParsedOptions) throws -> Int32 {
         if !parsed.flags.contains("--all") {
             if let contentGroup = simulatorContentRootElement(from: appRoot) {
                 targetRoot = contentGroup
+                usedSimulatorContentScope = true
             }
         }
     case .macApp:
@@ -32,6 +34,7 @@ func handleDescribeUI(_ parsed: ParsedOptions) throws -> Int32 {
     if let focusId = parsed.options["--focus-id"] {
         if let found = findAccessibilityElement(in: appRoot, identifier: focusId, label: nil) {
             targetRoot = found
+            usedSimulatorContentScope = false
         } else {
             throw NativeError.commandFailed("Could not find element with id: \(focusId)")
         }
@@ -41,6 +44,7 @@ func handleDescribeUI(_ parsed: ParsedOptions) throws -> Int32 {
     if let rootElementId = parsed.options["--root-element-id"] {
         if let found = findAccessibilityElement(in: appRoot, identifier: rootElementId, label: nil) {
             targetRoot = found
+            usedSimulatorContentScope = false
         } else {
             throw NativeError.commandFailed("Could not find element with id: \(rootElementId)")
         }
@@ -68,9 +72,15 @@ func handleDescribeUI(_ parsed: ParsedOptions) throws -> Int32 {
         }
     }
 
-    let lines = describeAccessibilityTree(from: targetRoot, options: descOpts)
+    var lines = describeAccessibilityTree(from: targetRoot, options: descOpts)
     if lines.isEmpty {
         throw NativeError.commandFailed("No accessibility elements found.")
+    }
+    if usedSimulatorContentScope {
+        let auxiliaryLabels = simulatorAuxiliaryContainerLabels(from: appRoot, excluding: targetRoot)
+        if let hint = formatSimulatorAuxiliaryContainerHint(auxiliaryLabels) {
+            lines.append(hint)
+        }
     }
     let report = lines.joined(separator: "\n")
 
@@ -95,8 +105,10 @@ func handleSearchUI(_ parsed: ParsedOptions) throws -> Int32 {
 
     let appRoot = try accessibilityRootElement(for: target)
     var searchRoot = appRoot
+    var simulatorContentRoot: UIElement? = nil
     if case .simulator = target {
         if let contentGroup = simulatorContentRootElement(from: appRoot) {
+            simulatorContentRoot = contentGroup
             searchRoot = contentGroup
         }
     }
@@ -117,7 +129,23 @@ func handleSearchUI(_ parsed: ParsedOptions) throws -> Int32 {
     }
 
     let results = searchAccessibilityElements(in: searchRoot, query: query, options: searchOpts)
-    if results.isEmpty {
+    if results.isEmpty, case .simulator = target, let simulatorContentRoot {
+        let auxiliaryCandidates = simulatorAuxiliaryContainerCandidates(from: appRoot, excluding: simulatorContentRoot)
+        let auxiliaryResults = searchAccessibilityElements(
+            in: auxiliaryCandidates.map(\.element),
+            query: query,
+            options: searchOpts
+        )
+        if auxiliaryResults.isEmpty {
+            print("No elements found matching query: \(query) in simulator app content or auxiliary containers.")
+            if let hint = formatSimulatorAuxiliaryContainerHint(auxiliaryCandidates.map(\.label)) {
+                print(hint)
+            }
+        } else {
+            print("[Fallback] No matches in simulator content scope; searched auxiliary containers outside iOSContentGroup.")
+            print(auxiliaryResults.joined(separator: "\n"))
+        }
+    } else if results.isEmpty {
         print("No elements found matching query: \(query)")
     } else {
         print(results.joined(separator: "\n"))
@@ -142,15 +170,21 @@ func handleTap(_ parsed: ParsedOptions) throws -> Int32 {
         }
 
         let root = try accessibilityRootElement(for: target)
-        let searchRoot: UIElement
+        let simulatorContentRoot = simulatorContentRootElement(from: root)
+        let searchRoots: [UIElement]
         if case .simulator = target, !includeAll {
-            searchRoot = simulatorContentRootElement(from: root) ?? root
+            if let contentRoot = simulatorContentRoot {
+                let auxiliaryRoots = simulatorAuxiliaryContainerCandidates(from: root, excluding: contentRoot).map(\.element)
+                searchRoots = [contentRoot] + auxiliaryRoots
+            } else {
+                searchRoots = [root]
+            }
         } else {
-            searchRoot = root
+            searchRoots = [root]
         }
 
         guard let matchedElement = findAccessibilityElement(
-            in: searchRoot,
+            in: searchRoots,
             identifier: accessibilityId,
             label: accessibilityLabel
         ) else {
@@ -163,7 +197,10 @@ func handleTap(_ parsed: ParsedOptions) throws -> Int32 {
             }
             let selectorText = selectors.joined(separator: " and ")
             if case .simulator = target, !includeAll {
-                throw NativeError.commandFailed("No accessibility element matched \(selectorText) in simulator app content. Try --all to include Simulator chrome UI.")
+                let auxiliaryLabels = simulatorContentRoot.map {
+                    simulatorAuxiliaryContainerLabels(from: root, excluding: $0)
+                } ?? []
+                throw NativeError.commandFailed(simulatorSelectorNotFoundMessage(selectorText: selectorText, auxiliaryLabels: auxiliaryLabels))
             }
             throw NativeError.commandFailed("No accessibility element matched \(selectorText).")
         }
@@ -243,12 +280,7 @@ func handleTapTab(_ parsed: ParsedOptions) throws -> Int32 {
     try activateTarget(target)
 
     let appRoot = try accessibilityRootElement(for: target)
-    let searchRoot: UIElement
-    if case .simulator = target {
-        searchRoot = simulatorContentRootElement(from: appRoot) ?? appRoot
-    } else {
-        searchRoot = appRoot
-    }
+    let searchRoot: UIElement = appRoot
 
     guard let tabBar = findTabBarElement(in: searchRoot) else {
         throw NativeError.commandFailed("No tab bar found in the application UI. Ensure the app has a visible tab bar.")

--- a/native/Sources/Utils.swift
+++ b/native/Sources/Utils.swift
@@ -734,6 +734,21 @@ func findAccessibilityElement(
     return nil
 }
 
+func findAccessibilityElement(
+    in roots: [UIElement],
+    identifier: String?,
+    label: String?,
+    maxDepth: Int = Int.max,
+    maxNodes: Int = Int.max
+) -> UIElement? {
+    for root in roots {
+        if let match = findAccessibilityElement(in: root, identifier: identifier, label: label, maxDepth: maxDepth, maxNodes: maxNodes) {
+            return match
+        }
+    }
+    return nil
+}
+
 func searchAccessibilityElements(in root: UIElement, query: String, options: SearchOptions = SearchOptions()) -> [String] {
     var results: [String] = []
     var stack: [(element: UIElement, depth: Int)] = [(root, 0)]
@@ -822,6 +837,14 @@ func searchAccessibilityElements(in root: UIElement, query: String, options: Sea
     return results
 }
 
+func searchAccessibilityElements(in roots: [UIElement], query: String, options: SearchOptions = SearchOptions()) -> [String] {
+    var results: [String] = []
+    for root in roots {
+        results.append(contentsOf: searchAccessibilityElements(in: root, query: query, options: options))
+    }
+    return results
+}
+
 func findElementBySubrole(from root: UIElement, subrole: String) -> UIElement? {
     var stack: [UIElement] = [root]
     var visited = 0
@@ -843,6 +866,151 @@ func findElementBySubrole(from root: UIElement, subrole: String) -> UIElement? {
 
 func simulatorContentRootElement(from appRoot: UIElement) -> UIElement? {
     return findElementBySubrole(from: appRoot, subrole: "iOSContentGroup")
+}
+
+struct SimulatorAuxiliaryContainerCandidate {
+    let element: UIElement
+    let label: String
+}
+
+func elementsAreEqual(_ lhs: UIElement, _ rhs: UIElement) -> Bool {
+    CFEqual(lhs, rhs)
+}
+
+func collectElements(
+    in root: UIElement,
+    matching predicate: (UIElement, Int) -> Bool,
+    maxVisited: Int = 500,
+    maxMatches: Int = 8
+) -> [UIElement] {
+    var stack: [(element: UIElement, depth: Int)] = [(root, 0)]
+    var visited = 0
+    var matches: [UIElement] = []
+
+    while let current = stack.popLast() {
+        if visited >= maxVisited || matches.count >= maxMatches {
+            break
+        }
+        visited += 1
+
+        if predicate(current.element, current.depth) {
+            matches.append(current.element)
+        }
+
+        for child in Children(current.element).reversed() {
+            stack.append((child, current.depth + 1))
+        }
+    }
+
+    return matches
+}
+
+func collectElementsByRole(in root: UIElement, role: String, maxMatches: Int = 4) -> [UIElement] {
+    collectElements(
+        in: root,
+        matching: { element, _ in
+            let attrs = copyMultipleAttributes(element, [kAXRoleAttribute as String])
+            if let ref = attrs[kAXRoleAttribute as String], let value = stringFromCFTypeRef(ref) {
+                return value == role
+            }
+            return false
+        },
+        maxMatches: maxMatches
+    )
+}
+
+func collectWideAuxiliaryGroups(in root: UIElement, contentRootFrame: CGRect? = nil, maxMatches: Int = 4) -> [UIElement] {
+    guard let mainScreen = NSScreen.main else { return [] }
+    let screenWidth = mainScreen.frame.width
+    let screenHeight = mainScreen.frame.height
+    let topThreshold = screenHeight * 0.20
+    let bottomThreshold = screenHeight * 0.20
+
+    return collectElements(
+        in: root,
+        matching: { element, _ in
+            let attrs = copyMultipleAttributes(element, [kAXRoleAttribute as String, "AXFrame"])
+            guard let ref = attrs[kAXRoleAttribute as String], let role = stringFromCFTypeRef(ref), role == "AXGroup" else {
+                return false
+            }
+            guard let frameRef = attrs["AXFrame"], let frame = frameFromCFTypeRef(frameRef) else {
+                return false
+            }
+            guard frame.width > screenWidth * 0.6 else {
+                return false
+            }
+            guard frame.origin.y < topThreshold || frame.origin.y > screenHeight - bottomThreshold else {
+                return false
+            }
+            if let contentRootFrame, contentRootFrame.contains(frame) {
+                return false
+            }
+            return Children(element).count >= 2
+        },
+        maxMatches: maxMatches
+    )
+}
+
+func simulatorAuxiliaryContainerCandidates(from appRoot: UIElement, excluding contentRoot: UIElement? = nil) -> [SimulatorAuxiliaryContainerCandidate] {
+    let contentRootFrame = contentRoot.flatMap(FrameAttribute)
+    let roleCandidates: [(role: String, label: String)] = [
+        ("AXTabGroup", "tab bar"),
+        ("AXRadioGroup", "radio group"),
+        ("AXSegmentedControl", "segmented control"),
+        ("AXToolbar", "toolbar"),
+    ]
+
+    var candidates: [SimulatorAuxiliaryContainerCandidate] = []
+
+    func appendCandidate(_ element: UIElement, label: String) {
+        if let contentRoot, elementsAreEqual(element, contentRoot) {
+            return
+        }
+        if let candidateFrame = FrameAttribute(element), let contentRootFrame, contentRootFrame.contains(candidateFrame) {
+            return
+        }
+        if candidates.contains(where: { elementsAreEqual($0.element, element) }) {
+            return
+        }
+        candidates.append(SimulatorAuxiliaryContainerCandidate(element: element, label: label))
+    }
+
+    for roleCandidate in roleCandidates {
+        for element in collectElementsByRole(in: appRoot, role: roleCandidate.role) {
+            appendCandidate(element, label: roleCandidate.label)
+        }
+    }
+
+    for element in collectWideAuxiliaryGroups(in: appRoot, contentRootFrame: contentRootFrame) {
+        appendCandidate(element, label: "auxiliary group")
+    }
+
+    return candidates
+}
+
+func simulatorAuxiliaryContainerLabels(from appRoot: UIElement, excluding contentRoot: UIElement? = nil) -> [String] {
+    simulatorAuxiliaryContainerCandidates(from: appRoot, excluding: contentRoot).map(\.label)
+}
+
+func formatSimulatorAuxiliaryContainerHint(_ labels: [String]) -> String? {
+    var seen: Set<String> = []
+    let uniqueLabels = labels.filter { label in
+        let normalized = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return false }
+        return seen.insert(normalized).inserted
+    }
+    guard !uniqueLabels.isEmpty else {
+        return nil
+    }
+    let containerList = uniqueLabels.joined(separator: ", ")
+    return "[Hint] Simulator auxiliary containers outside iOSContentGroup: \(containerList). Use --all to inspect Simulator chrome UI."
+}
+
+func simulatorSelectorNotFoundMessage(selectorText: String, auxiliaryLabels: [String]) -> String {
+    if let hint = formatSimulatorAuxiliaryContainerHint(auxiliaryLabels) {
+        return "No accessibility element matched \(selectorText) in simulator app content or auxiliary containers. \(hint)"
+    }
+    return "No accessibility element matched \(selectorText) in simulator app content. Try --all to include Simulator chrome UI."
 }
 
 func findTabBarElement(in root: UIElement) -> UIElement? {

--- a/tests/unit.test.mjs
+++ b/tests/unit.test.mjs
@@ -14,7 +14,8 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
-import { writeFileSync, chmodSync, mkdirSync, rmSync, rmdirSync, readFileSync } from "node:fs";
+import { writeFileSync, chmodSync, mkdirSync, rmSync, rmdirSync, readFileSync, mkdtempSync, readdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -35,6 +36,62 @@ function extractText(result) {
     .filter((item) => item.type === "text")
     .map((item) => item.text)
     .join("\n");
+}
+
+function listSwiftSources(directory) {
+  const entries = readdirSync(directory, { withFileTypes: true });
+  return entries
+    .flatMap((entry) => {
+      const fullPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        return listSwiftSources(fullPath);
+      }
+      if (entry.isFile() && entry.name.endsWith(".swift") && entry.name !== "main.swift") {
+        return [fullPath];
+      }
+      return [];
+    })
+    .sort();
+}
+
+let swiftProbeBinaryInfo = null;
+
+process.on("exit", () => {
+  if (swiftProbeBinaryInfo?.tempDir) {
+    rmSync(swiftProbeBinaryInfo.tempDir, { recursive: true, force: true });
+  }
+});
+
+function ensureSwiftProbeBinary() {
+  if (swiftProbeBinaryInfo) {
+    return swiftProbeBinaryInfo;
+  }
+
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "baepsae-swift-probe-"));
+  const binaryPath = path.join(tempDir, "probe");
+  const harnessPath = path.join(tempDir, "Probe.swift");
+  const sourceFiles = listSwiftSources(path.join(projectRoot, "native", "Sources"));
+  const harnessSource = `
+import Foundation
+
+@main
+struct Probe {
+  static func main() {
+    print(formatSimulatorAuxiliaryContainerHint([]) ?? "nil")
+    print(formatSimulatorAuxiliaryContainerHint(["tab bar", "toolbar", "tab bar"]) ?? "nil")
+    print(simulatorSelectorNotFoundMessage(selectorText: "label='Settings'", auxiliaryLabels: ["tab bar", "toolbar"]))
+    print(simulatorSelectorNotFoundMessage(selectorText: "id='foo'", auxiliaryLabels: []))
+  }
+}
+`;
+
+  writeFileSync(harnessPath, harnessSource);
+  execFileSync("swiftc", [...sourceFiles, harnessPath, "-o", binaryPath], {
+    stdio: "pipe",
+  });
+
+  swiftProbeBinaryInfo = { tempDir, binaryPath };
+  return swiftProbeBinaryInfo;
 }
 
 async function withClient(run, envOverrides = {}) {
@@ -921,6 +978,40 @@ test("query_ui forwards optional filter parameters", async () => {
     assert.match(text, /--visible-only/, "Should forward --visible-only");
     assert.match(text, /--max-depth/, "Should forward --max-depth");
   });
+});
+
+// ===========================================================================
+// Section 11b: Swift helper formatting for simulator auxiliary containers
+// ===========================================================================
+
+test("Swift helper formats simulator auxiliary container hints without duplicates", async () => {
+  const { binaryPath } = ensureSwiftProbeBinary();
+  const output = execFileSync(binaryPath, [], { encoding: "utf8" });
+  const [emptyHint, dedupHint] = output.trim().split("\n");
+
+  assert.equal(emptyHint, "nil", "Empty auxiliary label list should return nil");
+  assert.match(dedupHint, /tab bar/);
+  assert.match(dedupHint, /toolbar/);
+  assert.equal((dedupHint.match(/tab bar/g) ?? []).length, 1, "Duplicate labels should be removed");
+  assert.match(dedupHint, /Use --all/);
+});
+
+test("Swift helper selector fallback message mentions auxiliary containers when available", async () => {
+  const { binaryPath } = ensureSwiftProbeBinary();
+  const output = execFileSync(binaryPath, [], { encoding: "utf8" });
+  const lines = output.trim().split("\n");
+  const auxiliaryMessage = lines[2];
+  const contentOnlyMessage = lines[3];
+
+  assert.match(auxiliaryMessage, /label='Settings'/);
+  assert.match(auxiliaryMessage, /auxiliary containers/);
+  assert.match(auxiliaryMessage, /tab bar/);
+  assert.match(auxiliaryMessage, /toolbar/);
+  assert.match(auxiliaryMessage, /Use --all|Try --all/);
+
+  assert.match(contentOnlyMessage, /id='foo'/);
+  assert.match(contentOnlyMessage, /simulator app content/);
+  assert.match(contentOnlyMessage, /Try --all/);
 });
 
 // ===========================================================================


### PR DESCRIPTION
## Summary
- add a narrow simulator auxiliary-container fallback for selector-based discovery outside the default iOS content scope
- improve `tap`, `query_ui`, `analyze_ui`, and `tap_tab` handling for tab bars / toolbars / segmented-control style blind spots
- add Swift-helper/unit coverage for auxiliary container hints and selector failure messaging

## Testing
- npm ci
- node --test tests/unit.test.mjs
- swift test --package-path native
- npm test

Closes #42