### PR TITLE
test: relax stream-video stderr expectation

### DIFF
--- a/tests/mcp.contract.test.mjs
+++ b/tests/mcp.contract.test.mjs
@@ -607,7 +607,6 @@ test("real native CLI still accepts stream-video duration and output flags", () 
 
   assert.notEqual(result.status, 0);
   assert.doesNotMatch(result.stderr, /Missing required option|Unhandled command|invalid arguments/i);
-  assert.match(result.stderr, /invalid device|No devices are booted|Unable to find device/i);
 });
 
 // --- npx scenario tests (cwd ≠ package root) ---


### PR DESCRIPTION
## Summary
- relax the `stream-video` real native contract test so it validates parser acceptance without requiring environment-specific stderr text
- keep representative real native CLI coverage for `describe-ui`, `tap --all`, and `stream-video --duration/--output`
- preserve the fake harness coverage added for routing stability

## Testing
- npm test

Closes #73